### PR TITLE
Revert "force audio through speaker"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ proguard/
 captures/
 
 # IntelliJ
+.idea
 *.iml
 android/.idea/workspace.xml
 android/.idea/tasks.xml

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ def safeExtGet(prop, fallback) {
 buildscript {
     repositories {
         google()
-        maven { url 'https://artifactory.navkit-pipeline.tt3.com/artifactory/maven-remotes' }
+        maven { url 'https://artifactory.tomtomgroup.com/artifactory/maven-remotes' }
     }
 
     dependencies {


### PR DESCRIPTION
Revert android changes for forcing audio over speaker as this does not fully work.

Should be merged before [PR](https://github.com/tomtom-international/react-native-tts/pull/17)

Added update of artifactory url from [PR](https://github.com/tomtom-international/react-native-tts/pull/17)